### PR TITLE
Provide option to log raw text rather than a JSON structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You must have an HTTP source created in your Sumo Logic account to use this SDK.
 
 *Basics:*
 
-All logs are sent as JSON objects. If you call `log()` with just a string, the string is included as a field called `msg`. If you call the function with a JSON object, each field in the object is included as a separate field. Fields called `sessionId`, `url`, and `timestamp` are sent in both cases.
+All logs are sent as JSON objects by default. If you call `log()` with just a string, the string is included as a field called `msg`. If you call the function with a JSON object, each field in the object is included as a separate field. Fields called `sessionId`, `url`, and `timestamp` are sent in both cases.
 
 Messages are batched and sent at the configured interval; default is zero, meaning messages are sent to the server on each call. You can force any queued messages to be sent, typically during a shutdown or logout flow.
 
@@ -17,17 +17,20 @@ Messages are batched and sent at the configured interval; default is zero, meani
 | In keeping with industry standard security best practices, as of May 31, 2018, the Sumo Logic service will only support TLS version 1.2 going forward. Verify that all connections to Sumo Logic endpoints are made from software that supports TLS 1.2. |
 
 ### Table of Contents
-* [Installation](#installation)
-* [Demos](#demos)
-* [Usage](#usage)
-    * [Configuration](#configuration)
-    * [Per Message Options](#per-message-options)
-* [Usage Examples](#usage-examples)
-* [Security Note](#security-note)
-* [Tests](#tests)
-* [Issues](#issues)
-* [Credits](#credits)
-* [License](#license)
+- [Sumo Logic JavaScript Logging SDK](#sumo-logic-javascript-logging-sdk)
+    - [Table of Contents](#table-of-contents)
+  - [Installation](#installation)
+  - [Demos](#demos)
+  - [Usage](#usage)
+    - [Core functions](#core-functions)
+    - [Configuration](#configuration)
+    - [Per Message Options](#per-message-options)
+    - [Usage Examples](#usage-examples)
+  - [Security Note](#security-note)
+  - [Tests](#tests)
+  - [Issues](#issues)
+  - [Credits](#credits)
+  - [License](#license)
 
 ## Installation
 
@@ -109,6 +112,10 @@ You can provide a function that is executed if an error occurs when the logs are
 *graphite (optional, Node version only)*
 
 Enables graphite metrics sending.
+
+*raw (optional, Node version only)*
+
+Enables sending raw text logs exactly as they are passed to the logger.
 
 *clientUrl (optional, Node version only)*
 

--- a/src/sumoLogger.js
+++ b/src/sumoLogger.js
@@ -41,7 +41,8 @@ class SumoLogger {
             session: newConfig.sessionKey || getUUID(),
             onSuccess: newConfig.onSuccess || NOOP,
             onError: newConfig.onError || NOOP,
-            graphite: newConfig.graphite || false
+            graphite: newConfig.graphite || false,
+            raw: newConfig.raw || false,
         };
     }
 
@@ -174,6 +175,9 @@ class SumoLogger {
         const messages = message.map((item) => {
             if (this.config.graphite) {
                 return `${item.path} ${item.value} ${Math.round(ts.getTime() / 1000)}`;
+            }
+            if (this.config.raw) {
+                return item;
             }
             if (typeof item === 'string') {
                 return JSON.stringify(assignIn({

--- a/test/sumoLogger.test.js
+++ b/test/sumoLogger.test.js
@@ -216,12 +216,33 @@ describe('sumoLogger', () => {
             );
         });
 
-        it('should send log message exactly as provided if raw option enabled', () => {
+        it('should send a single log message exactly as provided if raw option enabled', () => {
             const logger = new SumoLogger({
                 endpoint,
                 raw: true
             });
             
+            logger.log(message, {
+                timestamp,
+                sessionKey
+            });
+
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                message, {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
+        });
+
+        it('should send an array of log messages exactly as provided if raw option enabled', () => {
+            const logger = new SumoLogger({
+                endpoint,
+                raw: true
+            });
+
             logger.log([message], {
                 timestamp,
                 sessionKey

--- a/test/sumoLogger.test.js
+++ b/test/sumoLogger.test.js
@@ -216,6 +216,27 @@ describe('sumoLogger', () => {
             );
         });
 
+        it('should send log message exactly as provided if raw option enabled', () => {
+            const logger = new SumoLogger({
+                endpoint,
+                raw: true
+            });
+            
+            logger.log([message], {
+                timestamp,
+                sessionKey
+            });
+
+            expect(axios.post).to.have.been.calledWithMatch(
+                endpoint,
+                message, {
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                }
+            );
+        });
+
         it('should call the onSuccess callback if the request succeeds', (done) => {
             axios.post.resolves({ status: 200 });
 


### PR DESCRIPTION
Hi,

We had a need with our specific internal setup to not log a JSON object, but rather log an entry as plain text.

This small change introduces the `raw` configuration option that allows for simply directly logging the provided message rather than wrapping it in the JSON object. It is `false` by default, so the current behaviour is retained.

Please let me know if there's anything that needs changing.