### PR TITLE
Remove axios from dependencies (fixes #78)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "superagent": "^5.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
- Since axios was abandoned in favor of SuperAgent, it should be removed from the dependencies, as it's triggering vulnerability alerts
- Due to [vulnerability CVE-2019-10742](https://nvd.nist.gov/vuln/detail/CVE-2019-10742)
- See [issue #78](https://github.com/SumoLogic/js-sumo-logger/issues/78) for details.