### PR TITLE
Prevent throwing when batchSize and raw specified 

### DIFF
--- a/src/sumoLogger.js
+++ b/src/sumoLogger.js
@@ -105,7 +105,7 @@ class SumoLogger {
             return this.config.interval === 0;
         } else {
             const pendingMessages = this.pendingLogs.reduce((acc, curr) => {
-                const log = JSON.parse(curr);
+                const log = typeof curr === 'string' ? curr : JSON.parse(curr);
                 return acc + log.msg + '\n';
             }, '');
             const pendingBatchSize = pendingMessages.length;


### PR DESCRIPTION
when both are specified, the JSON.parse call throws.